### PR TITLE
Add support for joining a channel if the app hasn't been added manually

### DIFF
--- a/chime_repeaters_observer.py
+++ b/chime_repeaters_observer.py
@@ -40,6 +40,12 @@ def send_message_to_slack(blocks, debug=False):
             print("Got an error: %s" % (e.response["error"]))
             print(blocks)
             print()
+
+            if e.response["error"] == "not_in_channel":
+                resp = client.conversations_list(types="public_channel")['channels']
+                print(resp)
+                channel_id = [channel['id'] for channel in resp if channel['name'] == CHANNEL[1:]][0]
+                client.conversations_join(channel=channel_id)
     return []
 
 


### PR DESCRIPTION
Hey Dany,

Quick patch if you want to use it; I was testing out the bot and found that if it wasn't manually added to a channel it would fail on startup, so I added support for searching the visible channels for the target channel, and joining if it is present.

Unfrtunately though, this causes some bloat to the required OAuth permissions, mostly from the attempts to list public channels:
"channels:join", "channels:read", "groups:history", "groups:read", "im:read", "mpim:read"

Cheers for the handy bot either way